### PR TITLE
Added french locale

### DIFF
--- a/_locales/fr/joystickbit-strings.json
+++ b/_locales/fr/joystickbit-strings.json
@@ -1,0 +1,17 @@
+{
+  "joystickbit.ButtonType.down|block": "pressé",
+  "joystickbit.ButtonType.up|block": "relâché",
+  "joystickbit.JoystickBitPin.P12|block": "C",
+  "joystickbit.JoystickBitPin.P13|block": "D",
+  "joystickbit.JoystickBitPin.P14|block": "E",
+  "joystickbit.JoystickBitPin.P15|block": "F",
+  "joystickbit.Vibration_Motor|block": "vibrer le moteur pour %time ms",
+  "joystickbit.getButton|block": "bouton %button est pressé",
+  "joystickbit.getRockerValue|block": "valeur du rockeur %rocker",
+  "joystickbit.initJoystickBit|block": "initialisation joystick:bit",
+  "joystickbit.onButtonEvent|block": "quand le bouton %button|est %event",
+  "joystickbit.rockerType.X|block": "X",
+  "joystickbit.rockerType.Y|block": "Y",
+  "joystickbit|block": "Joystickbit",
+  "{id:category}Joystickbit": "Joystickbit"
+}

--- a/pxt.json
+++ b/pxt.json
@@ -9,7 +9,8 @@
     "files": [
         "README.md",
         "joystickbit.ts",
-        "_locales/zh/joystickbit-strings.json"
+        "_locales/zh/joystickbit-strings.json",
+        "_locales/fr/joystickbit-strings.json"
     ],
     "testFiles": [
         "tests.ts"


### PR DESCRIPTION
We're currently using this extension for Makecode to teach programming and electronics at [kikicode](https://en.kikicode.ca/).
The only problem is that our courses are given in french, and we noticed this extention did not have french translations.

I added the `fr` locale in order to fix this. 