### PR TITLE
Czech translation

### DIFF
--- a/_locales/cs/joystickbit-jsdoc-strings.json
+++ b/_locales/cs/joystickbit-jsdoc-strings.json
@@ -1,0 +1,10 @@
+{
+    "joystickbit": "Bezdrátově ovládej své výtvory pomocí joystick:bit.",
+    "joystickbit.Vibration_Motor": "Zapne vibrační motor na zvolenou dobu.",
+    "joystickbit.Vibration_Motor|param|time": "Doba zapnutí vibračního motoru v ms, např. 100.",
+    "joystickbit.getButton": "Zjistí, zda je zvolené tlačítko stisknuto.",
+    "joystickbit.getRockerValue": "Zjistí polohu levé páčky na zvolené ose.",
+    "joystickbit.getRockerValue|param|rocker": "Osa levé páčky, např. X.",
+    "joystickbit.initJoystickBit": "Inicializuje joystick:bit.",
+    "joystickbit.onButtonEvent": "Spustí se při zaznamenání joystick:bit události."
+}

--- a/_locales/cs/joystickbit-strings.json
+++ b/_locales/cs/joystickbit-strings.json
@@ -1,0 +1,17 @@
+{
+  "joystickbit.ButtonType.down|block": "stisknuto",
+  "joystickbit.ButtonType.up|block": "uvolněno",
+  "joystickbit.JoystickBitPin.P12|block": "C",
+  "joystickbit.JoystickBitPin.P13|block": "D",
+  "joystickbit.JoystickBitPin.P14|block": "E",
+  "joystickbit.JoystickBitPin.P15|block": "F",
+  "joystickbit.Vibration_Motor|block": "vibruj po dobu %time ms",
+  "joystickbit.getButton|block": "je tlačítko %button(C) stisknuto",
+  "joystickbit.getRockerValue|block": "poloha levé páčky na ose %rocker(X)",
+  "joystickbit.initJoystickBit|block": "inicializuj joystick:bit",
+  "joystickbit.onButtonEvent|block": "tlačíko %button(C)| je %event(stisknuto)",
+  "joystickbit.rockerType.X|block": "X",
+  "joystickbit.rockerType.Y|block": "Y",
+  "joystickbit|block": "Joystickbit",
+  "{id:category}Joystickbit": "Joystickbit"
+}

--- a/joystickbit.ts
+++ b/joystickbit.ts
@@ -70,8 +70,8 @@ namespace joystickbit {
 
 
     /**
-    * get rocker value
-    * @param rocker describe parameter here, eg: 1
+    * Reads rocker value for the defined axis.
+    * @param rocker rocker axis to read
     */
     //% blockId=getRockerValue block="rocker value of %rocker"
     export function getRockerValue(rocker: rockerType): number {
@@ -106,4 +106,4 @@ namespace joystickbit {
 
 
 }
- 
+

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "joystickbit",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "ELECFREAKS joystick:bit package",
     "license": "MIT",
     "dependencies": {
@@ -11,7 +11,9 @@
         "joystickbit.ts",
         "_locales/zh/joystickbit-strings.json",
         "_locales/fr/joystickbit-strings.json",
-        "_locales/zh-TW/joystickbit-strings.json"
+        "_locales/zh-TW/joystickbit-strings.json",
+        "_locales/cs/joystickbit-strings.json",
+        "_locales/cs/joystickbit-jsdoc-strings.json"
     ],
     "testFiles": [
         "tests.ts"


### PR DESCRIPTION
This is my first attempt to translate an extension for my kids to be able to code `joystick:bit` when getting one on Christmas.

Got inspired by the https://github.com/elecfreaks/pxt-TPBot/pull/11 😊 

There are 2 issues though:
1. In JS mode, the parameters are in English and the `rockerType` Enum suggests `number 1`.
2. The `blockId=onButtonEvent block="on button %button|is %event"` block refuses to show my translation 😞

Any idea why? @elecfreaks1 @almasy 

<img width="1064" alt="Screenshot 2024-11-10 at 20 21 37" src="https://github.com/user-attachments/assets/2774fc95-d291-4a87-b250-54b3ec5a3127">
<img width="1047" alt="Blocks" src="https://github.com/user-attachments/assets/2cc787b8-f19e-4e3f-8d50-4fe0a64ff67e">
<img width="890" alt="Screenshot 2024-11-10 at 20 22 02" src="https://github.com/user-attachments/assets/15aa1c5f-8b8c-447c-8fca-b3ca432d954d">
